### PR TITLE
Remove AirportBrcmFixup.kext entry from Kernel/Add because kext is missing

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -316,24 +316,6 @@
 				<key>Arch</key>
 				<string>Any</string>
 				<key>BundlePath</key>
-				<string>AirportBrcmFixup.kext</string>
-				<key>Comment</key>
-				<string></string>
-				<key>Enabled</key>
-				<true/>
-				<key>ExecutablePath</key>
-				<string>Contents/MacOS/AirportBrcmFixup</string>
-				<key>MaxKernel</key>
-				<string></string>
-				<key>MinKernel</key>
-				<string></string>
-				<key>PlistPath</key>
-				<string>Contents/Info.plist</string>
-			</dict>
-			<dict>
-				<key>Arch</key>
-				<string>Any</string>
-				<key>BundlePath</key>
 				<string>SmallTreeIntel82576.kext</string>
 				<key>Comment</key>
 				<string>10 Gbits Intel Lan </string>


### PR DESCRIPTION
Small update to `config.plist`:  I have removed `AirportBrcmFixup.kext` entry from `Kernel/Add` because the kext itself is missing from `Kexts/`